### PR TITLE
feat: inline click-to-edit description on running timer cards

### DIFF
--- a/docs/superpowers/plans/2026-04-07-edit-tracking-entry-description.md
+++ b/docs/superpowers/plans/2026-04-07-edit-tracking-entry-description.md
@@ -1,0 +1,191 @@
+# Edit Tracking Entry Description — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to inline-edit the description of a running timer card in the tray view.
+
+**Architecture:** UI-only change in `TrayView.tsx`. Click the description text on a running timer card to enter edit mode (textarea). Enter/blur saves via existing `kimaiUpdateDescription` IPC. Escape cancels. No backend, IPC, or type changes needed.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS v4
+
+**Spec:** `docs/superpowers/specs/2026-04-07-edit-tracking-entry-description-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/components/TrayView.tsx` | Modify | Add edit state, save handler, replace static description with click-to-edit textarea |
+
+No other files are touched.
+
+---
+
+### Task 1: Add edit state variables
+
+**Files:**
+- Modify: `src/components/TrayView.tsx:57-59`
+
+- [ ] **Step 1: Add state declarations**
+
+After the existing panel state declarations (line 59), add:
+
+```tsx
+// Inline description editing
+const [editingTimerId, setEditingTimerId] = useState<number | null>(null);
+const [editDescription, setEditDescription] = useState('');
+```
+
+- [ ] **Step 2: Verify app still compiles**
+
+Run: `npm start` (or check terminal if already running)
+Expected: No errors, app renders normally. New state is unused — that's fine.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/TrayView.tsx
+git commit -m "feat: add inline description edit state to TrayView"
+```
+
+---
+
+### Task 2: Add save handler
+
+**Files:**
+- Modify: `src/components/TrayView.tsx` (after `handleDeleteTimesheet` around line 480)
+
+- [ ] **Step 1: Add the handleSaveDescription function**
+
+Insert after `handleDeleteTimesheet` (around line 480):
+
+```tsx
+const handleSaveDescription = async (timesheetId: number, newDescription: string, originalDescription: string) => {
+  if (!window.electronAPI) return;
+  if (newDescription === originalDescription) {
+    setEditingTimerId(null);
+    return;
+  }
+  try {
+    await window.electronAPI.kimaiUpdateDescription(timesheetId, newDescription);
+    setActiveTimers(prev => prev.map(t =>
+      t.timesheetId === timesheetId ? { ...t, description: newDescription } : t
+    ));
+  } catch (error) {
+    console.error('Failed to update description:', error);
+    showError('Failed to update description');
+  } finally {
+    setEditingTimerId(null);
+  }
+};
+```
+
+- [ ] **Step 2: Verify app still compiles**
+
+Run: Check terminal for errors.
+Expected: No errors. Function is defined but not yet called.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/TrayView.tsx
+git commit -m "feat: add handleSaveDescription for inline timer editing"
+```
+
+---
+
+### Task 3: Replace static description with click-to-edit
+
+**Files:**
+- Modify: `src/components/TrayView.tsx:1184-1188`
+
+- [ ] **Step 1: Replace the description display block**
+
+Find this block in the timer card (around lines 1184–1188):
+
+```tsx
+                  {timer.description && (
+                    <div className="text-xs text-muted-foreground mt-1 ml-4 truncate">
+                      {timer.description}
+                    </div>
+                  )}
+```
+
+Replace it with:
+
+```tsx
+                  <div className="mt-1 ml-4">
+                    {editingTimerId === timer.timesheetId ? (
+                      <textarea
+                        value={editDescription}
+                        onChange={(e) => setEditDescription(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && !e.shiftKey) {
+                            e.preventDefault();
+                            handleSaveDescription(timer.timesheetId, editDescription, timer.description);
+                          } else if (e.key === 'Escape') {
+                            setEditingTimerId(null);
+                          }
+                        }}
+                        onBlur={() => handleSaveDescription(timer.timesheetId, editDescription, timer.description)}
+                        autoFocus
+                        rows={2}
+                        className="w-full px-2 py-1 text-xs bg-background border border-border rounded focus:outline-none focus:ring-1 focus:ring-primary/50 focus:border-primary resize-none"
+                        placeholder="What are you working on?"
+                      />
+                    ) : (
+                      <button
+                        onClick={() => {
+                          setEditingTimerId(timer.timesheetId);
+                          setEditDescription(timer.description);
+                        }}
+                        className="text-xs text-muted-foreground truncate block w-full text-left hover:text-foreground transition-colors"
+                      >
+                        {timer.description || 'Add description...'}
+                      </button>
+                    )}
+                  </div>
+```
+
+- [ ] **Step 2: Verify the feature works end-to-end**
+
+Manual test in the running app:
+1. Start a timer with a description → the description shows in the timer card
+2. Click the description → it becomes a textarea with the current text
+3. Edit the text, press Enter → textarea disappears, new description shows
+4. Click description again, press Escape → reverts to original, no API call
+5. Click description, edit, click elsewhere (blur) → saves
+6. Start a timer with no description → "Add description..." placeholder shows
+7. Click the placeholder → empty textarea appears, type something, Enter → saves
+
+Expected: All 7 scenarios work as described.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/TrayView.tsx
+git commit -m "feat: inline click-to-edit description on running timer cards"
+```
+
+---
+
+### Task 4: Final verification
+
+- [ ] **Step 1: Test with multiple timers**
+
+1. Start two timers with different descriptions
+2. Click description on timer 1 → edit mode
+3. Click description on timer 2 → timer 1 saves via blur, timer 2 enters edit mode
+4. Both descriptions should be correct after editing
+
+- [ ] **Step 2: Test error handling**
+
+1. Disconnect from the network (or temporarily break the Kimai API URL in settings)
+2. Edit a description and press Enter
+3. Expect: error toast appears, description reverts
+
+- [ ] **Step 3: Test empty description**
+
+1. Edit a description to empty string, press Enter
+2. Expect: saves successfully, placeholder "Add description..." shows again

--- a/docs/superpowers/specs/2026-04-07-edit-tracking-entry-description-design.md
+++ b/docs/superpowers/specs/2026-04-07-edit-tracking-entry-description-design.md
@@ -1,0 +1,85 @@
+# Edit Description on Running Timer Card
+
+**Date:** 2026-04-07
+**Status:** Draft
+**Branch:** `edit-tracking-entry`
+
+## Summary
+
+Allow users to edit the description of a running timer directly from the timer card in the tray view, using an inline click-to-edit pattern.
+
+## Motivation
+
+After the multi-timer feature was shipped, users can run multiple concurrent timers. However, there's no way to edit a timer's description after it starts — you'd have to stop it, go to Kimai's web UI, edit it, then restart. This is disruptive. Users should be able to fix a typo or add context without interrupting their tracking session.
+
+## Scope
+
+- **In scope:** Editing the description text on a running timer card
+- **Out of scope:** Editing project, activity, customer, or Jira ticket on a running timer
+
+## Design
+
+### Interaction
+
+1. **Display mode (default):** The description line in each timer card is clickable. If no description exists, a faint "Add description..." placeholder is shown and is also clickable.
+2. **Edit mode:** Clicking the description replaces it with a `<textarea>` pre-filled with the current description. The textarea is auto-focused.
+3. **Save:** On **Enter** (without Shift) or **blur**, the new description is persisted via the existing `kimaiUpdateDescription` IPC channel, which updates both Kimai (with tracking prefix) and the local ActiveTimer store.
+4. **Cancel:** On **Escape**, the textarea reverts to the original text and exits edit mode.
+5. **Error:** If the API call fails, the existing error toast is shown and the description reverts.
+
+### State Changes (TrayView.tsx only)
+
+Two new state variables:
+
+- `editingTimerId: number | null` — which timer card is in edit mode (`null` = none)
+- `editDescription: string` — the current textarea value while editing
+
+### Data Flow
+
+```
+User clicks description
+  → editingTimerId = timer.timesheetId
+  → editDescription = timer.description
+
+User types
+  → editDescription updates locally
+
+User presses Enter / blurs
+  → call kimaiUpdateDescription(timesheetId, editDescription)
+  → on success: update activeTimers state with new description, editingTimerId = null
+  → on failure: show error toast, revert editDescription, editingTimerId = null
+
+User presses Escape
+  → editingTimerId = null (no API call)
+```
+
+### Backend
+
+**No changes required.** The existing infrastructure handles everything:
+
+- `IPC_CHANNELS.KIMAI_UPDATE_DESCRIPTION` — validates input, adds tracking prefix, calls Kimai PATCH, updates local store
+- `updateActiveTimer()` in store — already supports partial updates
+- `kimaiUpdateDescription()` in preload — already exposed to renderer
+
+### UI Details
+
+- The textarea should match the existing description text styling (text-xs, text-muted-foreground) so the transition feels seamless.
+- Textarea height: 2 rows, resizable vertically if needed.
+- Only one timer can be in edit mode at a time. Clicking a different timer's description triggers blur → save on the current one, then opens the new one.
+- The clickable description area should have a subtle hover indicator (e.g., slight background change or underline) to hint at editability.
+
+### Edge Cases
+
+- **Empty description:** Allowed. User can clear their description entirely.
+- **Multiple timers:** Only one editable at a time; switching saves the previous via blur.
+- **Timer stops while editing:** The timer card unmounts. No save needed — whatever was on Kimai already is fine.
+- **Rapid edits:** Each save is independent. No debouncing needed since saves are triggered by explicit user action (Enter/blur), not on every keystroke.
+- **Network failure:** Show error toast, revert to previous description in UI.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/components/TrayView.tsx` | Add `editingTimerId` and `editDescription` state. Add `handleSaveDescription` function. Replace static description line in timer card with click-to-edit textarea. |
+
+No changes to: `types.ts`, `preload.ts`, `index.ts`, `store.ts`, `kimai.ts`.

--- a/src/components/TrayView.tsx
+++ b/src/components/TrayView.tsx
@@ -58,6 +58,10 @@ export function TrayView() {
   const [recentEntriesOpen, setRecentEntriesOpen] = useState(false);
   const [activityPanelOpen, setActivityPanelOpen] = useState(false);
 
+  // Inline description editing
+  const [editingTimerId, setEditingTimerId] = useState<number | null>(null);
+  const [editDescription, setEditDescription] = useState('');
+
   // Theme state (using Electron's nativeTheme)
   const [themeMode, setThemeMode] = useState<ThemeMode>('system');
   const [isDark, setIsDark] = useState(false);
@@ -476,6 +480,25 @@ export function TrayView() {
     } catch (error) {
       console.error('Failed to delete timesheet:', error);
       showError('Failed to delete time entry');
+    }
+  };
+
+  const handleSaveDescription = async (timesheetId: number, newDescription: string, originalDescription: string) => {
+    if (!window.electronAPI) return;
+    if (newDescription === originalDescription) {
+      setEditingTimerId(null);
+      return;
+    }
+    try {
+      await window.electronAPI.kimaiUpdateDescription(timesheetId, newDescription);
+      setActiveTimers(prev => prev.map(t =>
+        t.timesheetId === timesheetId ? { ...t, description: newDescription } : t
+      ));
+    } catch (error) {
+      console.error('Failed to update description:', error);
+      showError('Failed to update description');
+    } finally {
+      setEditingTimerId(null);
     }
   };
 
@@ -1181,11 +1204,37 @@ export function TrayView() {
                       {activityNameCache[timer.activityId] || `Activity #${timer.activityId}`}
                     </span>
                   </div>
-                  {timer.description && (
-                    <div className="text-xs text-muted-foreground mt-1 ml-4 truncate">
-                      {timer.description}
-                    </div>
-                  )}
+                  <div className="mt-1 ml-4">
+                    {editingTimerId === timer.timesheetId ? (
+                      <textarea
+                        value={editDescription}
+                        onChange={(e) => setEditDescription(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && !e.shiftKey) {
+                            e.preventDefault();
+                            handleSaveDescription(timer.timesheetId, editDescription, timer.description);
+                          } else if (e.key === 'Escape') {
+                            setEditingTimerId(null);
+                          }
+                        }}
+                        onBlur={() => handleSaveDescription(timer.timesheetId, editDescription, timer.description)}
+                        autoFocus
+                        rows={2}
+                        className="w-full px-2 py-1 text-xs bg-background border border-border rounded focus:outline-none focus:ring-1 focus:ring-primary/50 focus:border-primary resize-none"
+                        placeholder="What are you working on?"
+                      />
+                    ) : (
+                      <button
+                        onClick={() => {
+                          setEditingTimerId(timer.timesheetId);
+                          setEditDescription(timer.description);
+                        }}
+                        className="text-xs text-muted-foreground truncate block w-full text-left hover:text-foreground transition-colors"
+                      >
+                        {timer.description || 'Add description...'}
+                      </button>
+                    )}
+                  </div>
                   {timer.jiraIssue && (
                     <div className="mt-1 ml-4">
                       <span className="text-[10px] font-mono px-1.5 py-0.5 bg-blue-500/10 text-blue-600 rounded">

--- a/src/components/TrayView.tsx
+++ b/src/components/TrayView.tsx
@@ -61,6 +61,7 @@ export function TrayView() {
   // Inline description editing
   const [editingTimerId, setEditingTimerId] = useState<number | null>(null);
   const [editDescription, setEditDescription] = useState('');
+  const [editOriginalDescription, setEditOriginalDescription] = useState('');
 
   // Theme state (using Electron's nativeTheme)
   const [themeMode, setThemeMode] = useState<ThemeMode>('system');
@@ -1212,12 +1213,12 @@ export function TrayView() {
                         onKeyDown={(e) => {
                           if (e.key === 'Enter' && !e.shiftKey) {
                             e.preventDefault();
-                            handleSaveDescription(timer.timesheetId, editDescription, timer.description);
+                            (e.target as HTMLTextAreaElement).blur();
                           } else if (e.key === 'Escape') {
                             setEditingTimerId(null);
                           }
                         }}
-                        onBlur={() => handleSaveDescription(timer.timesheetId, editDescription, timer.description)}
+                        onBlur={() => handleSaveDescription(timer.timesheetId, editDescription, editOriginalDescription)}
                         autoFocus
                         rows={2}
                         className="w-full px-2 py-1 text-xs bg-background border border-border rounded focus:outline-none focus:ring-1 focus:ring-primary/50 focus:border-primary resize-none"
@@ -1228,6 +1229,7 @@ export function TrayView() {
                         onClick={() => {
                           setEditingTimerId(timer.timesheetId);
                           setEditDescription(timer.description);
+                          setEditOriginalDescription(timer.description);
                         }}
                         className="text-xs text-muted-foreground truncate block w-full text-left hover:text-foreground transition-colors"
                       >


### PR DESCRIPTION
## Summary

- Add inline click-to-edit for timer descriptions on running timer cards in the tray view
- Click a description (or "Add description..." placeholder) to edit it in-place
- Enter/blur saves to Kimai, Escape cancels — single save code path via blur to prevent double-save race
- Leverages existing `kimaiUpdateDescription` IPC channel — no backend changes needed

## Changes

- `src/components/TrayView.tsx` — added `editingTimerId`, `editDescription`, `editOriginalDescription` state; `handleSaveDescription` handler; replaced static description div with click-to-edit textarea/button

## Test plan

- [ ] Start a timer with a description → click description → edit → press Enter → verify description updates in Kimai
- [ ] Start a timer → click description → press Escape → verify no API call, original text restored
- [ ] Start a timer → click description → edit → click elsewhere (blur) → verify description saves
- [ ] Start a timer with no description → verify "Add description..." placeholder shows → click it → type → Enter → saves
- [ ] Start two timers → edit description on timer 1 → click description on timer 2 → verify timer 1 saves via blur
- [ ] Edit description while offline → verify error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)